### PR TITLE
Fix activation string for JDK 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@ package.
   <profiles>
     <profile>
       <activation>
-        <jdk>[1.8</jdk>
+        <jdk>[1.8,)</jdk>
       </activation>
       <properties>
         <!-- FindBugs 2.0.x is not compatible with Java 8


### PR DESCRIPTION
Should be more compatible with IntelliJ.
