### PR TITLE
Exlcude yaml files from checkstyle checks.

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -5,7 +5,7 @@
   "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
-  <suppress checks=".*" files=".*(compressed.*\.js|min\.js|\.eot|\.gif|\.ico|\.patch|\.png|\.ttf|\.woff)" />
+  <suppress checks=".*" files=".*(compressed.*\.js|min\.js|\.eot|\.gif|\.ico|\.patch|\.png|\.ttf|\.woff|\.yml)" />
   <!-- Ignore old Liquibase changelogs -->
   <suppress checks=".*" files=".*db\.changelog-(1\..a?|2\..|3\.[01])\.xml" />
   <suppress checks=".*" files=".*db/.*_baseline\.sql" />


### PR DESCRIPTION
We can later add more fine-grained rules if so desired.
