### PR TITLE
Static check happen earlier in build lifecycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,16 +235,14 @@
           <excludes>src/test/resources/**</excludes>
           <sourceDirectory>${project.basedir}</sourceDirectory>
         </configuration>
-        <!--
-                <executions>
-                  <execution>
-                    <goals>
-                      <goal>check</goal>
-                    </goals>
-                    <phase>verify</phase>
-                  </execution>
-                </executions>
-        -->
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>test-compile</phase>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -280,6 +278,7 @@
             <goals>
               <goal>analyze-only</goal>
             </goals>
+            <phase>test-compile</phase>
           </execution>
         </executions>
         <configuration>
@@ -383,6 +382,7 @@ package.
             <goals>
               <goal>check</goal>
             </goals>
+            <phase>test-compile</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
So that we don't have to wait for tests to be run and know the result earlier(fail fast)
