### PR TITLE
Revert "run static checks earlier in build lifecycle"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,14 +234,16 @@
           <excludes>src/test/resources/**</excludes>
           <sourceDirectory>${project.basedir}</sourceDirectory>
         </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>test-compile</phase>
-          </execution>
-        </executions>
+        <!--
+                <executions>
+                  <execution>
+                    <goals>
+                      <goal>check</goal>
+                    </goals>
+                    <phase>verify</phase>
+                  </execution>
+                </executions>
+        -->
       </plugin>
 
       <plugin>
@@ -277,7 +279,6 @@
             <goals>
               <goal>analyze-only</goal>
             </goals>
-            <phase>test-compile</phase>
           </execution>
         </executions>
         <configuration>
@@ -381,7 +382,6 @@ package.
             <goals>
               <goal>check</goal>
             </goals>
-            <phase>test-compile</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
This reverts commit 67f95d0136bdc8648a2f04a2adf9de80cd92cd33.

On reflection, test-compile is not the right phase to be running
static analysis.  Plus it breaks zanata-server, because the
Cobertura enhancements are active when maven-dependency-plugin is
analysing the code.
