### PR TITLE
Stop dependency problems from breaking the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
           </execution>
         </executions>
         <configuration>
-          <failOnWarning>true</failOnWarning>
+          <failOnWarning>false</failOnWarning>
           <outputXML>true</outputXML>
           <usedDependencies combine.children="append">
             <!-- runtime-only dependencies which maven-dependency-analyzer misses  -->


### PR DESCRIPTION
The maven-dependency-plugin is too unpredictable to let it break the build.
