### PR TITLE
Update extra-enforcer-rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,16 @@
               <searchTransitive>true</searchTransitive>
             </bannedDependencies>
             <banDuplicateClasses>
+              <dependencies combine.children="append">
+                <dependency>
+                  <groupId>org.apache.httpcomponents</groupId>
+                  <artifactId>httpclient</artifactId>
+                  <ignoreClasses>
+                    <!-- also found in httpcore -->
+                    <ignoreClass>org.apache.http.annotation.*</ignoreClass>
+                  </ignoreClasses>
+                </dependency>
+              </dependencies>
               <findAllDuplicates>true</findAllDuplicates>
               <message xml:space="preserve">
 Warning: found duplicate classes on classpath.  Please remove unnecessary
@@ -394,7 +404,7 @@ package.
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.0-alpha-5</version>
+            <version>1.0-beta-2</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
Don't merge yet!

This will require break zanata-server unless we update the ignoreClasses section of its pom (because extra-enforcer-rules:1.0-alpha-5 hasn't actually worked properly since maven-enforcer-plugin was upgraded to 1.3).
