### PR TITLE
Remove -dirty suffix from git describe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,6 @@ package.
             <configuration>
               <descriptionProperty>gitDescribe</descriptionProperty>
               <extraArguments>
-                <param>--dirty</param>
               </extraArguments>
             </configuration>
           </execution>


### PR DESCRIPTION
The maven-release-plugin seems to use dirty working directories for
every build, so the dirty flag ends up pretty meaningless.
