### PR TITLE
Update enforcer exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,10 @@
                 <exclude>junit:junit-dep</exclude>
                 <exclude>xml-apis:xml-apis</exclude>
                 <exclude>xerces:xmlParserAPIs</exclude>
+
+                <!-- use com.google.code.findbugs:annotations -->
+                <exclude>net.jcip:jcip-annotations</exclude>
+
                 <exclude>net.sf.okapi.logbind:build-log4j</exclude>
                 <!--                         <exclude>javassist:javassist</exclude> -->
                 <!-- use org.apache.httpcomponents -->
@@ -341,6 +345,14 @@
                   <ignoreClasses>
                     <!-- also found in httpcore -->
                     <ignoreClass>org.apache.http.annotation.*</ignoreClass>
+                  </ignoreClasses>
+                </dependency>
+                <dependency>
+                  <groupId>commons-beanutils</groupId>
+                  <artifactId>commons-beanutils</artifactId>
+                  <ignoreClasses>
+                    <!-- caused by commons-beanutils less than 1.9 -->
+                    <ignoreClass>org.apache.commons.collections.*</ignoreClass>
                   </ignoreClasses>
                 </dependency>
               </dependencies>


### PR DESCRIPTION
This may fix the failures which were triggered by upgrading extra-enforcer-rules in commit ced4367.
