### PR TITLE
Remove banDuplicateClasses enforcer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,12 +389,6 @@
               </excludes>
               <searchTransitive>true</searchTransitive>
             </bannedDependencies>
-            <!-- TODO remove this once other modules are ready -->
-            <banDuplicateClasses>
-              <ignoreClasses combine.children="append">
-                <ignoreClass>*</ignoreClass>
-              </ignoreClasses>
-            </banDuplicateClasses>
             <requireNoRepositories>
               <message xml:space="preserve">Repositories in pom.xml are not allowed by Maven Central</message>
               <banRepositories>true</banRepositories>


### PR DESCRIPTION
Replaced by maven-duplicate-finder-plugin.  See
   https://github.com/zanata/zanata-parent/pull/28 and
   https://github.com/zanata/zanata-parent/commit/04a7b8d

NB: This should not be merged until after https://github.com/zanata/zanata-client/pull/29 and https://github.com/zanata/zanata-server/pull/549.
