### PR TITLE
do not fail build when there is no test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -458,10 +458,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <useFile>false</useFile>
-          <failIfNoTests>true</failIfNoTests>
-          <!-- TODO set to true?
           <failIfNoTests>false</failIfNoTests>
-           -->
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Although it claims to have a user property failIfNoTests but it doesn't work for me. If we can't override the value at runtime we better set it to false. This will enable easier jenkins build and submodule execution.
