### PR TITLE
Update maven-site-plugin to version 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -614,7 +614,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.0-beta-2</version>
+          <version>3.4</version>
         </plugin>
         <plugin>
           <groupId>org.eclipse.m2e</groupId>


### PR DESCRIPTION
This is needed for running `mvn site` with newer versions of maven,
otherwise an exception is generated by a missing class.
