### PR TITLE
Replace/update maven-duplicate-finder-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,11 +316,11 @@
         </configuration>
       </plugin>
 
-      <!-- https://github.com/ning/maven-duplicate-finder-plugin -->
+      <!-- https://github.com/basepom/duplicate-finder-maven-plugin -->
       <plugin>
-        <groupId>com.ning.maven.plugins</groupId>
-        <artifactId>maven-duplicate-finder-plugin</artifactId>
-        <version>1.0.7</version>
+        <groupId>org.basepom.maven</groupId>
+        <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <version>1.1.1</version>
         <configuration>
           <failBuildInCaseOfDifferentContentConflict>true</failBuildInCaseOfDifferentContentConflict>
           <!--<printEqualFiles>true</printEqualFiles>-->


### PR DESCRIPTION
The maven-duplicate-finder-plugin has been superceded by
duplicate-finder-maven-plugin.