### PR TITLE
chore(checkstyle): prevent checkstyle failure on tabs in Makefile

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -18,6 +18,8 @@
   <suppress checks="FileTabCharacter" files="/src/test/.*\.(xml|po|pot)$" />
   <!-- Allow indented here documents -->
   <suppress checks="FileTabCharacter" files="\.sh$" />
+  <!-- Allow required tabs in Makefile -->
+  <suppress checks="FileTabCharacter" files="(.*/)*[Mm]akefile$" />
   <suppress checks="JavadocMethodCheck|JavadocTypeCheck" files="\.java$" />
   <suppress checks="MagicNumberCheck" files="Test\.java$" />
   <suppress checks="NewlineAtEndOfFile" files="\.properties$" />


### PR DESCRIPTION
Make requires tab-indentation in Makefiles so it is not valid to fail a style check on them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-parent/61)
<!-- Reviewable:end -->
